### PR TITLE
uncrustify selected text

### DIFF
--- a/BBUncrustifyPlugin.xcodeproj/project.pbxproj
+++ b/BBUncrustifyPlugin.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		14FF378D16F490F60049868C /* BBUncrustify.m in Sources */ = {isa = PBXBuildFile; fileRef = 14FF378C16F490F60049868C /* BBUncrustify.m */; };
 		DA1B5D020E64686800921439 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 089C1672FE841209C02AAC07 /* Foundation.framework */; };
 		DA37E2DC0E6291C8001BDFEF /* BBUncrustifyPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = DA37E2DB0E6291C8001BDFEF /* BBUncrustifyPlugin.m */; };
+		E331943516FF83720015D6DC /* MWSubstring.m in Sources */ = {isa = PBXBuildFile; fileRef = E331943416FF83720015D6DC /* MWSubstring.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,8 @@
 		8D5B49B6048680CD000E48DA /* UncrustifyPlugin.xcplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UncrustifyPlugin.xcplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D5B49B7048680CD000E48DA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA37E2DB0E6291C8001BDFEF /* BBUncrustifyPlugin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BBUncrustifyPlugin.m; sourceTree = "<group>"; };
+		E331943316FF83720015D6DC /* MWSubstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWSubstring.h; sourceTree = "<group>"; };
+		E331943416FF83720015D6DC /* MWSubstring.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWSubstring.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +114,8 @@
 				141251A116F4AA8600A18D23 /* BBXcode.m */,
 				14FF378B16F490F60049868C /* BBUncrustify.h */,
 				14FF378C16F490F60049868C /* BBUncrustify.m */,
+				E331943316FF83720015D6DC /* MWSubstring.h */,
+				E331943416FF83720015D6DC /* MWSubstring.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -183,6 +188,7 @@
 				DA37E2DC0E6291C8001BDFEF /* BBUncrustifyPlugin.m in Sources */,
 				14FF378D16F490F60049868C /* BBUncrustify.m in Sources */,
 				141251A216F4AA8600A18D23 /* BBXcode.m in Sources */,
+				E331943516FF83720015D6DC /* MWSubstring.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Classes/BBXcode.h
+++ b/Classes/BBXcode.h
@@ -8,6 +8,12 @@
 
 #import <Cocoa/Cocoa.h>
 
+@interface DVTCompletingTextView : NSTextView
+@end
+
+@interface DVTSourceTextView : DVTCompletingTextView
+@end
+
 @interface DVTTextDocumentLocation : NSObject
 - (NSRange)characterRange;
 @end
@@ -49,8 +55,10 @@
 @end
 
 @interface IDESourceCodeEditor : NSObject
+- (DVTSourceTextView *)textView;
 - (IDESourceCodeDocument *)sourceCodeDocument;
 - (NSArray *)currentSelectedDocumentLocations; // DVTTextDocumentLocation objects
+- (id)undoManagerForTextView:(id)textView;
 @end
 
 @interface IDEEditorContext : NSObject

--- a/Classes/MWSubstring.h
+++ b/Classes/MWSubstring.h
@@ -1,0 +1,17 @@
+//
+//  MWSubstring.h
+//  BBUncrustifyPlugin
+//
+//  Created by Daniel Ericsson on 2013-03-24.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MWSubstring : NSObject
+
+@property (nonatomic, readwrite, copy) NSString *string;
+@property (nonatomic, readwrite, assign) NSRange range;
+
+- (id)initWithString:(NSString *)aString rangeValue:(NSRange)aRange;
+
+@end

--- a/Classes/MWSubstring.m
+++ b/Classes/MWSubstring.m
@@ -1,0 +1,21 @@
+//
+//  MWSubstring.m
+//  BBUncrustifyPlugin
+//
+//  Created by Daniel Ericsson on 2013-03-24.
+//
+
+#import "MWSubstring.h"
+
+@implementation MWSubstring
+
+- (id)initWithString:(NSString *)aString rangeValue:(NSRange)aRange {
+    if (self = [super init]) {
+        _string = aString;
+        _range = aRange;
+    }
+
+    return self;
+}
+
+@end


### PR DESCRIPTION
Hi,

I've been using an automator action to uncrustify, but an Xcode plugin is way nicer.

I have an old Mac Pro I can't update to 10.8 and the uncrustify-binary you had included crashed for me on 10.7, so I've replaced it with one built from Macports, I've tested it on 10.7 and 10.8 (Xcode 4.6.1).

My old automator action worked by piping selected text so I've extended the plugin with a new menu item to uncrustify the current selection (multiple selection supported).

thanks!
