### PR TITLE
Uncrustify And Reindent Selected Lines

### DIFF
--- a/Classes/BBXcode.h
+++ b/Classes/BBXcode.h
@@ -52,8 +52,13 @@
 - (NSUndoManager *)undoManager;
 @end
 
+@interface DVTSourceTextView : NSTextView
+- (void)indentSelectionIfIndentable:(id)sender;
+- (void)indentSelection:(id)sender;
+@end
+
 @interface IDESourceCodeEditor : NSObject
-@property(retain) NSTextView *textView;
+@property(retain) DVTSourceTextView *textView;
 - (IDESourceCodeDocument *)sourceCodeDocument;
 - (NSArray *)currentSelectedDocumentLocations; // DVTTextDocumentLocation objects
 @end
@@ -75,5 +80,5 @@
 + (id)currentEditor;
 + (NSArray *)selectedObjCFileNavigableItems;
 + (BOOL)uncrustifyCodeOfDocument:(IDESourceCodeDocument *)document;
-+ (BOOL)uncrustifyCodeAtRanges:(NSArray *)ranges document:(IDESourceCodeDocument *)document;
++ (BOOL)uncrustifyCodeAtRanges:(NSArray *)ranges document:(IDESourceCodeDocument *)document reindent:(BOOL)reindent;
 @end

--- a/Classes/BBXcode.m
+++ b/Classes/BBXcode.m
@@ -82,7 +82,7 @@ NSArray *BBMergeContinuousRanges(NSArray* ranges) {
     return uncrustified;
 }
 
-+ (BOOL)uncrustifyCodeAtRanges:(NSArray *)ranges document:(IDESourceCodeDocument *)document {
++ (BOOL)uncrustifyCodeAtRanges:(NSArray *)ranges document:(IDESourceCodeDocument *)document reindent:(BOOL)reindent {
     BOOL uncrustified = NO;
     DVTSourceTextStorage *textStorage = [document textStorage];
     
@@ -125,7 +125,7 @@ NSArray *BBMergeContinuousRanges(NSArray* ranges) {
         uncrustified = YES;
     }
     
-    if (uncrustified) {
+    if (uncrustified && reindent) {
         [textStorage indentCharacterRange:NSMakeRange(0, textStorage.string.length) undoManager:[document undoManager]];
     }
     


### PR DESCRIPTION
IMHO Xcode does a better job at indenting code than uncrustify.

I added an option to automatically copy-paste the text view's contents after running uncrustify.

This gives Xcode a chance to re-indent the code.

Pasteboard is archive for this operation and restored afterwards.
