### PR TITLE
Configuration file per project

### DIFF
--- a/Classes/BBUncrustify.m
+++ b/Classes/BBUncrustify.m
@@ -7,6 +7,7 @@
 //
 
 #import "BBUncrustify.h"
+#import "BBXcode.h"
 #import <Cocoa/Cocoa.h>
 
 static NSString * const BBUncrustifyXBundleIdentifier = @"nz.co.xwell.UncrustifyX";
@@ -103,9 +104,21 @@ static NSString * BBUUIDString() {
 }
 
 + (NSArray *)proposedConfigurationFileURLs {
+    NSMutableArray *proposedURLs = [NSMutableArray array];
     NSURL *homeDirectoryURL = [NSURL fileURLWithPath:NSHomeDirectory()];
-    NSArray *array = @[[homeDirectoryURL URLByAppendingPathComponent:@".uncrustifyconfig" isDirectory:NO], [homeDirectoryURL URLByAppendingPathComponent:@"uncrustify.cfg" isDirectory:NO]];
-    return array;
+    NSURL *projectDirectoryURL = [BBXcode projectHomeDirectoryURL];
+
+    if (projectDirectoryURL) {
+        [proposedURLs addObject:
+            [projectDirectoryURL URLByAppendingPathComponent:@"uncrustify.cfg" isDirectory:NO]];
+    }
+
+    [proposedURLs addObject:
+        [homeDirectoryURL URLByAppendingPathComponent:@".uncrustifyconfig" isDirectory:NO]];
+    [proposedURLs addObject:
+        [homeDirectoryURL URLByAppendingPathComponent:@"uncrustify.cfg" isDirectory:NO]];
+
+    return proposedURLs;
 }
 
 + (NSURL *)configurationFileURL {

--- a/Classes/BBXcode.h
+++ b/Classes/BBXcode.h
@@ -88,4 +88,5 @@
 + (NSArray *)selectedObjCFileNavigableItems;
 + (BOOL)uncrustifyCodeOfDocument:(IDESourceCodeDocument *)document;
 + (BOOL)uncrustifyCodeAtRanges:(NSArray *)ranges document:(IDESourceCodeDocument *)document;
++ (NSURL *)projectHomeDirectoryURL; // returns the directory contains .xcodeproj
 @end

--- a/Classes/BBXcode.m
+++ b/Classes/BBXcode.m
@@ -46,6 +46,26 @@ NSString * BBStringByTrimmingTrailingCharactersFromString(NSString *string, NSCh
     return nil;
 }
 
++ (NSURL *)projectHomeDirectoryURL {
+    id currentWindowController = [[NSApp keyWindow] windowController];
+    id document = [currentWindowController document];
+
+    if ([document isKindOfClass:NSClassFromString(@"IDEWorkspaceDocument")]) {
+        NSURL *fileURL = [document fileURL];
+        NSMutableArray *components = [NSMutableArray arrayWithArray:[fileURL pathComponents]];
+
+        if ([[[components lastObject] pathExtension] isEqualToString:@"xcworkspace"]) {
+            [components removeLastObject];
+        }
+        if ([[[components lastObject] pathExtension] isEqualToString:@"xcodeproj"]) {
+            [components removeLastObject];
+            return [NSURL fileURLWithPath:[NSString pathWithComponents:components]
+                              isDirectory:YES];
+        }
+    }
+    return nil;
+}
+
 + (IDESourceCodeDocument *)currentSourceCodeDocument {
     if ([[BBXcode currentEditor] isKindOfClass:NSClassFromString(@"IDESourceCodeEditor")]) {
         IDESourceCodeEditor *editor = [BBXcode currentEditor];

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ You can create keyboard shortcuts for the menu items in the [Keyboard Preference
 
 By default, the plugin uses the configuration file `uncrustify.cfg` found in the bundle.
 
-To customize the configuration, copy the file `uncrustify.cfg` or your own to `~/uncrustify.cfg` or `~/.uncrustifyconfig`.
+To customize the configuration, copy the file `uncrustify.cfg` or your own to:
+
+1. `uncrustify.cfg` in the same directory of your `.xcodeproj` file or
+2. `~/.uncrustifyconfig` or
+3. `~/uncrustify.cfg`
 
 ### Using UncrustifyX
 


### PR DESCRIPTION
For developers who are working on the project which has its own coding standards, the plugin will read `uncrustify.cfg` in project directory at first.

```
|-- project.xcodeproj
+-- uncrustify.cfg
```
