### PR TITLE
Formatting selected files won’t stop when error occurs

### DIFF
--- a/Classes/XCFPlugin.m
+++ b/Classes/XCFPlugin.m
@@ -84,11 +84,10 @@ static XCFPlugin *sharedPlugin = nil;
 #pragma mark - Actions
 
 - (IBAction)formatSelectedFiles:(id)sender {
-    NSError *error = nil;
-    [XCFXcodeFormatter formatSelectedFilesWithError:&error];
-    if (error) {
-        [[NSAlert alertWithError:error] runModal];
-    }
+	[XCFXcodeFormatter formatSelectedFilesWithErrorBlock:^(NSError *error, BOOL *stop) {
+		[[NSAlert alertWithError:error] runModal];
+		*stop = NO;
+	}];
     [[BBPluginUpdater sharedUpdater] checkForUpdatesIfNeeded];
 }
 

--- a/Classes/XCFXcodeFormatter.h
+++ b/Classes/XCFXcodeFormatter.h
@@ -12,6 +12,7 @@
 
 + (BOOL)canFormatSelectedFiles;
 + (void)formatSelectedFilesWithError:(NSError **)outError;
++ (void)formatSelectedFilesWithErrorBlock:(void(^)(NSError *error, BOOL *stop))errorBlock;
 
 + (BOOL)canFormatActiveFile;
 + (void)formatActiveFileWithError:(NSError **)outError;

--- a/Classes/XCFXcodeFormatter.m
+++ b/Classes/XCFXcodeFormatter.m
@@ -27,6 +27,32 @@ NSString * XCFStringByTrimmingTrailingCharactersFromString(NSString *string, NSC
     return (selectedFiles.count > 0);
 }
 
++ (void)formatSelectedFilesWithErrorBlock:(void(^)(NSError *error, BOOL *stop))errorBlock
+{
+	NSArray *fileNavigableItems = [XCFXcodeFormatter selectedSourceCodeFileNavigableItems];
+    IDEWorkspace *currentWorkspace = [XCFXcodeFormatter currentWorkspaceDocument].workspace;
+    for (IDEFileNavigableItem *fileNavigableItem in fileNavigableItems) {
+		NSError *error = nil;
+        NSDocument *document = [IDEDocumentController retainedEditorDocumentForNavigableItem:fileNavigableItem error:nil];
+        if ([document isKindOfClass:NSClassFromString(@"IDESourceCodeDocument")]) {
+            IDESourceCodeDocument *sourceCodeDocument = (IDESourceCodeDocument *)document;
+            [XCFXcodeFormatter uncrustifyCodeOfDocument:sourceCodeDocument inWorkspace:currentWorkspace error:&error];
+            //[document saveDocument:nil];
+        }
+        [IDEDocumentController releaseEditorDocument:document];
+		
+		if (error) {
+			BOOL __block stop = NO;
+			if (errorBlock) {
+				errorBlock(error, &stop);
+			}
+			if (stop) {
+				break;
+			}
+		}
+    }
+}
+
 + (void)formatSelectedFilesWithError:(NSError **)outError {
     NSArray *fileNavigableItems = [XCFXcodeFormatter selectedSourceCodeFileNavigableItems];
     IDEWorkspace *currentWorkspace = [XCFXcodeFormatter currentWorkspaceDocument].workspace;


### PR DESCRIPTION
As I am using "Format selected files" option to apply formatting on all files in several projects, it was annoying for me that when uncrustify can't format a given file, the plugin stops and display error information. This change should make the plugin to display error information when it occurs and continue formatting other selected files.
