### PR TITLE
Added _uncrustify.cfg and .uncrustify.cfg as additional local directory conf file names.

### DIFF
--- a/Classes/XCFFormatterUtilities.m
+++ b/Classes/XCFFormatterUtilities.m
@@ -69,7 +69,7 @@
 
 + (NSURL *)configurationFileURLForPresentedURL:(NSURL *)presentedURL {
     
-    NSArray *lookupFilenames = @[@"uncrustify.cfg", @".uncrustifyconfig"];
+    NSArray *lookupFilenames = @[@"uncrustify.cfg", @"_uncrustify.cfg", @".uncrustify.cfg", @".uncrustifyconfig"];
 
     static NSArray *alternateURLs = nil;
     
@@ -82,7 +82,9 @@
             [array addObject:[homeDirectoryURL URLByAppendingPathComponent:lookupFilename isDirectory:NO]];
         }
         
-        [array addObject:[[homeDirectoryURL URLByAppendingPathComponent:@".uncrustify" isDirectory:YES] URLByAppendingPathComponent:@"uncrustify.cfg" isDirectory:NO]];
+        [array addObject:[[homeDirectoryURL URLByAppendingPathComponent:@".uncrustify"
+                                                            isDirectory:YES]
+                          URLByAppendingPathComponent:@"uncrustify.cfg" isDirectory:NO]];
         
         NSURL *builtInConfigurationFileURL = [[self class] builtinConfigurationFileURL];
         if (builtInConfigurationFileURL) {

--- a/Resources/XCFPreferencesWindowController.xib
+++ b/Resources/XCFPreferencesWindowController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment defaultVersion="1080" identifier="macosx"/>
         <development version="5000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5053"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="XCFPreferencesWindowController">
@@ -103,7 +103,7 @@
                     <popUpButton verticalHuggingPriority="750" id="hmF-Jb-6Cg">
                         <rect key="frame" x="260" y="295" width="222" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <popUpButtonCell key="cell" type="push" title="Create Configuration File" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="ahf-Ce-kMh" id="hGj-Um-eeO">
+                        <popUpButtonCell key="cell" type="push" title="Create Configuration File" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="oAS-CE-fbV" id="hGj-Um-eeO">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="menu"/>
                             <menu key="menu" title="OtherViews" id="8qD-YN-qRc">
@@ -201,13 +201,13 @@
                         <font key="titleFont" metaFont="system"/>
                     </box>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="ClM-zt-hRr">
-                        <rect key="frame" x="261" y="206" width="442" height="84"/>
+                        <rect key="frame" x="261" y="178" width="442" height="112"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" id="efP-zs-V45">
                             <font key="font" metaFont="smallSystem"/>
-                            <string key="title">The configuration file must be located in the current directory or any parent directories of the source file.
-- For Clang, the file is named `.clang-format` or `_clang-format`.
-- For Uncrustify, the file is named `.uncrustifyconfig` or `uncrustify.cfg`. Uncrustify looks for the configuration in the additional folders: `Home Folder` and `~/.uncrustify/uncrustify.cfg`.</string>
+                            <mutableString key="title">The configuration file must be located in the current directory or any parent directories of the source file. BBUncrustifyPlugin looks for the following file name patterns, in the order shown:
+- For Clang: _clang-format, .clang-format
+- For Uncrustify: uncrustify.cfg, _uncrustify.cfg, .uncrustify.cfg, .uncrustifyconfig    In addition: your Home Folder and ~/.uncrustify/uncrustify.cfg</mutableString>
                             <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>


### PR DESCRIPTION
Added _uncrustify.cfg and .uncrustify.cfg as optional local directory config file names. Updated search order (check for .cfg files first). Updated xib file paragraph instructions for config file name and search location.

The first option (with underscore) was added for consistency with _clang-format naming scheme, and the second was added as a more intuitive/concise version than "uncrustifyconfig ". It's a matter of opinion for sure, but like .gitignore, I believe that non application build-related files should be preceded by a dot. Usually, the uncrustify configuration would be standardized for an organization and copied into each project, again, similar to a .gitignore file.
