### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+xcodebuild:=xcodebuild -scheme "BBUncrustifyPlugin-ARC" -configuration
+
+debug:
+	$(xcodebuild) Debug
+
+release:
+	$(xcodebuild) Release
+
+clean: clean-release clean-debug
+
+clean-debug:
+	$(xcodebuild) Debug clean
+
+clean-release:
+	$(xcodebuild) Release clean
+
+uninstall:
+	rm -rf "$(HOME)/Library/Application Support/Developer/Shared/Xcode/Plug-ins/UncrustifyPlugin.xcplugin"
+


### PR DESCRIPTION
make and xcodebuild is bundled with Xcode, so everybody kan just type 'make' to compile and install the plugin.